### PR TITLE
Allow semicolon statement terminator

### DIFF
--- a/src/SpiceWeaver.Parser/SchemaParser.cs
+++ b/src/SpiceWeaver.Parser/SchemaParser.cs
@@ -17,12 +17,13 @@ public static class SchemaParser
     private static readonly Parser<char, string> _relationExpression =
         Tok(
                 Map(
-                    (first, rest) => first + rest,
+                    (first, rest, _) => first + rest,
                     Lowercase,
                     OneOf(
                             Lowercase, Digit, Char('_'), Char('#'), Char(':'), Char('*'), Char('|'), Char(' ')
                         )
-                        .ManyString()
+                        .ManyString(),
+                    StatementTerminator
                 )
             )
             .Labelled("relationExpression");
@@ -43,12 +44,13 @@ public static class SchemaParser
 
     private static readonly Parser<char, string> _permissionExpression =
         Tok(Map(
-                (first, rest) => first + rest,
+                (first, rest, _) => first + rest,
                 Lowercase,
                 OneOf(
                         Lowercase, Digit, Char('_'), Char('-'), Char('>'), Char('+'), Char(' '), Char('-'), Char('&')
                     )
-                    .ManyString()
+                    .ManyString(),
+                StatementTerminator
             ))
             .Labelled("permissionExpression");
 

--- a/src/SpiceWeaver.Parser/UtilityParsers.cs
+++ b/src/SpiceWeaver.Parser/UtilityParsers.cs
@@ -11,6 +11,18 @@ internal static class UtilityParsers
     public static readonly Parser<char, char> Colon = Tok(':');
     public static readonly Parser<char, char> Equal = Tok('=');
 
+    public static readonly Parser<char, Unit> StatementTerminator = Tok(
+        OneOf(
+            Whitespace.IgnoreResult(),
+            Char(';').IgnoreResult(),
+            Lookahead((OneOf(
+                Try(Char('}').IgnoreResult()),
+                Try(String("//").IgnoreResult()),
+                Try(String("/*").IgnoreResult())
+            )))
+        )
+    );
+
     public static readonly Parser<char, string> Identifier =
         Tok(
             Map(

--- a/src/SpiceWeaver.Parser/UtilityParsers.cs
+++ b/src/SpiceWeaver.Parser/UtilityParsers.cs
@@ -15,11 +15,14 @@ internal static class UtilityParsers
         OneOf(
             Whitespace.IgnoreResult(),
             Char(';').IgnoreResult(),
-            Lookahead((OneOf(
-                Try(Char('}').IgnoreResult()),
-                Try(String("//").IgnoreResult()),
-                Try(String("/*").IgnoreResult())
-            )))
+            Lookahead(
+                OneOf(
+                    Try(Char('}').IgnoreResult()),
+                    Try(String("//").IgnoreResult()),
+                    // Need to find out if block comments are allowed within statements
+                    Try(String("/*").IgnoreResult())
+                )
+            )
         )
     );
 

--- a/tests/SpiceWeaver.Tests/Parser/SchemaParserTests.cs
+++ b/tests/SpiceWeaver.Tests/Parser/SchemaParserTests.cs
@@ -347,22 +347,31 @@ public class SchemaParserTests
     [Test]
     public void MultipleStatementsOnSingleLine()
     {
-        var input = $"definition document {{ relation foo: bar; permission foo = bar; relation foo: bar }}";
+        var input =
+            "definition document { relation viewer: user; relation organization: organization; permission view = viewer; }";
 
         var expected = new Schema(new[]
         {
             new Definition("document", new[]
             {
-                new Relation("foo", "bar"), new Relation("foo", "bar")
+                new Relation("viewer", "user"), new Relation("organization", "organization")
             }, new[]
             {
-                new Permission("foo", "bar")
+                new Permission("view", "viewer")
             })
         });
-        
+
         AssertEquivalent(input, expected);
     }
 
+    [Test]
+    public void SingleSlashDoesNotTerminateStatement()
+    {
+        // Ensuring that comment termination works correctly and only // and /* can terminate the statement
+        var input = "definition document { relation viewer: user / permission view = viewer }";
+
+        AssertFailure(input);
+    }
 
     private static void AssertEquivalent(string input, Schema expected)
     {


### PR DESCRIPTION
Fixes #11

This will also treat comments and close braces as terminators (without consuming them, using a lookahead)