### PR TITLE
Add support for namespaces

### DIFF
--- a/tests/SpiceWeaver.Tests/CodeGeneratorTests.cs
+++ b/tests/SpiceWeaver.Tests/CodeGeneratorTests.cs
@@ -54,6 +54,14 @@ public sealed class CodeGeneratorTests
         Snapshot.Match(output);
     }
 
+    [Test]
+    public void GenerateFromJson_WhenDefinitionsIncludeNamespaces_ShouldGenerateExpectedOutput()
+    {
+        var output = CodeGenerator.Generate("TestNameSpace", "TestSchema", TestSchema.WithNamespacesJson);
+        
+        Snapshot.Match(output);
+    }
+
     private static IEnumerable<string?> NullOrWhitespace =>
     [
         null,

--- a/tests/SpiceWeaver.Tests/TestSchema.cs
+++ b/tests/SpiceWeaver.Tests/TestSchema.cs
@@ -5,74 +5,146 @@ namespace SpiceWeaver.Tests;
 public static class TestSchema
 {
     public const string SpiceDb = """
-                                 definition user {}
+                                  definition user {}
 
-                                 definition document {
-                                  relation viewer: user
-                                  relation editor: user
-                                  
-                                  permission view = viewer + editor
-                                  permission edit = editor
-                                 }
-                                 """;
+                                  definition document {
+                                   relation viewer: user
+                                   relation editor: user
+                                   
+                                   permission view = viewer + editor
+                                   permission edit = editor
+                                  }
+                                  """;
 
     public static readonly Schema Object = JsonConvert.DeserializeObject<Schema>(Json)!;
 
     public const string Json = """
-                                     {
-                                       "definitions": [
-                                         {
-                                           "name": "user"
-                                         },
-                                         {
-                                           "name": "document",
-                                           "relations": [
+                               {
+                                 "definitions": [
+                                   {
+                                     "name": "user"
+                                   },
+                                   {
+                                     "name": "document",
+                                     "relations": [
+                                       {
+                                         "name": "viewer",
+                                         "types": [
+                                           {
+                                             "type": "user"
+                                           }
+                                         ]
+                                       },
+                                       {
+                                         "name": "editor",
+                                         "types": [
+                                           {
+                                             "type": "user"
+                                           }
+                                         ]
+                                       }
+                                     ],
+                                     "permissions": [
+                                       {
+                                         "name": "view",
+                                         "userSet": {
+                                           "operation": "union",
+                                           "children": [
                                              {
-                                               "name": "viewer",
-                                               "types": [
-                                                 {
-                                                   "type": "user"
-                                                 }
-                                               ]
+                                               "relation": "viewer"
                                              },
                                              {
-                                               "name": "editor",
-                                               "types": [
-                                                 {
-                                                   "type": "user"
-                                                 }
-                                               ]
-                                             }
-                                           ],
-                                           "permissions": [
-                                             {
-                                               "name": "view",
-                                               "userSet": {
-                                                 "operation": "union",
-                                                 "children": [
-                                                   {
-                                                     "relation": "viewer"
-                                                   },
-                                                   {
-                                                     "relation": "editor"
-                                                   }
-                                                 ]
-                                               }
-                                             },
-                                             {
-                                               "name": "edit",
-                                               "userSet": {
-                                                 "operation": "union",
-                                                 "children": [
-                                                   {
-                                                     "relation": "editor"
-                                                   }
-                                                 ]
-                                               }
+                                               "relation": "editor"
                                              }
                                            ]
                                          }
-                                       ]
-                                     }
-                                     """;
+                                       },
+                                       {
+                                         "name": "edit",
+                                         "userSet": {
+                                           "operation": "union",
+                                           "children": [
+                                             {
+                                               "relation": "editor"
+                                             }
+                                           ]
+                                         }
+                                       }
+                                     ]
+                                   }
+                                 ]
+                               }
+                               """;
+
+    public const string WithNamespaces = """
+                                         definition mynamespace/user {}
+                                                                                 
+                                         definition mynamespace/document {
+                                             relation viewer: user
+                                             relation editor: user
+                                             
+                                             permission view = viewer + editor
+                                             permission edit = editor
+                                         }
+                                         """;
+
+    public const string WithNamespacesJson = """
+                                             {
+                                               "definitions": [
+                                                 {
+                                                   "name": "user",
+                                                   "namespace": "mynamespace"
+                                                 },
+                                                 {
+                                                   "name": "document",
+                                                   "namespace": "mynamespace",
+                                                   "relations": [
+                                                     {
+                                                       "name": "viewer",
+                                                       "types": [
+                                                         {
+                                                           "type": "user"
+                                                         }
+                                                       ]
+                                                     },
+                                                     {
+                                                       "name": "editor",
+                                                       "types": [
+                                                         {
+                                                           "type": "user"
+                                                         }
+                                                       ]
+                                                     }
+                                                   ],
+                                                   "permissions": [
+                                                     {
+                                                       "name": "view",
+                                                       "userSet": {
+                                                         "operation": "union",
+                                                         "children": [
+                                                           {
+                                                             "relation": "viewer"
+                                                           },
+                                                           {
+                                                             "relation": "editor"
+                                                           }
+                                                         ]
+                                                       }
+                                                     },
+                                                     {
+                                                       "name": "edit",
+                                                       "userSet": {
+                                                         "operation": "union",
+                                                         "children": [
+                                                           {
+                                                             "relation": "editor"
+                                                           }
+                                                         ]
+                                                       }
+                                                     }
+                                                   ]
+                                                 }
+                                               ]
+                                             }
+                                             """;
 }

--- a/tests/SpiceWeaver.Tests/__snapshots__/CodeGeneratorTests.GenerateFromJson_ShouldGenerateExpectedOutput.snap
+++ b/tests/SpiceWeaver.Tests/__snapshots__/CodeGeneratorTests.GenerateFromJson_ShouldGenerateExpectedOutput.snap
@@ -7,13 +7,15 @@
             public static class User
             {
                 public const string Name = "user";
-                public static string WithId(string id) => $"user:{id}";
+                public const string? Namespace = null;
+                public static string WithId(string id, bool includeNamespace = false) => $"user:{id}";
             }
 
             public static class Document
             {
                 public const string Name = "document";
-                public static string WithId(string id) => $"document:{id}";
+                public const string? Namespace = null;
+                public static string WithId(string id, bool includeNamespace = false) => $"document:{id}";
                 public static class Relations
                 {
                     public const string Viewer = "viewer";

--- a/tests/SpiceWeaver.Tests/__snapshots__/CodeGeneratorTests.GenerateFromJson_WhenDefinitionsIncludeNamespaces_ShouldGenerateExpectedOutput.snap
+++ b/tests/SpiceWeaver.Tests/__snapshots__/CodeGeneratorTests.GenerateFromJson_WhenDefinitionsIncludeNamespaces_ShouldGenerateExpectedOutput.snap
@@ -1,21 +1,21 @@
-﻿namespace SpiceWeaver
+﻿namespace TestNameSpace
 {
-    public static class Schema
+    public static class TestSchema
     {
         public static class Definitions
         {
             public static class User
             {
                 public const string Name = "user";
-                public const string? Namespace = null;
-                public static string WithId(string id, bool includeNamespace = false) => $"user:{id}";
+                public const string? Namespace = "mynamespace";
+                public static string WithId(string id, bool includeNamespace = false) => includeNamespace ? $"mynamespace/user:{id}" : $"user:{id}";
             }
 
             public static class Document
             {
                 public const string Name = "document";
-                public const string? Namespace = null;
-                public static string WithId(string id, bool includeNamespace = false) => $"document:{id}";
+                public const string? Namespace = "mynamespace";
+                public static string WithId(string id, bool includeNamespace = false) => includeNamespace ? $"mynamespace/document:{id}" : $"document:{id}";
                 public static class Relations
                 {
                     public const string Viewer = "viewer";

--- a/tests/SpiceWeaver.Tests/__snapshots__/CodeGeneratorTests.GenerateFromSchema_ShouldGenerateExpectedOutput.snap
+++ b/tests/SpiceWeaver.Tests/__snapshots__/CodeGeneratorTests.GenerateFromSchema_ShouldGenerateExpectedOutput.snap
@@ -7,13 +7,15 @@
             public static class User
             {
                 public const string Name = "user";
-                public static string WithId(string id) => $"user:{id}";
+                public const string? Namespace = null;
+                public static string WithId(string id, bool includeNamespace = false) => $"user:{id}";
             }
 
             public static class Document
             {
                 public const string Name = "document";
-                public static string WithId(string id) => $"document:{id}";
+                public const string? Namespace = null;
+                public static string WithId(string id, bool includeNamespace = false) => $"document:{id}";
                 public static class Relations
                 {
                     public const string Viewer = "viewer";

--- a/tests/SpiceWeaver.Tests/__snapshots__/SchemaSourceGeneratorTests.MultipleSchemas_Mixed_bar.snap
+++ b/tests/SpiceWeaver.Tests/__snapshots__/SchemaSourceGeneratorTests.MultipleSchemas_Mixed_bar.snap
@@ -7,13 +7,15 @@
             public static class User
             {
                 public const string Name = "user";
-                public static string WithId(string id) => $"user:{id}";
+                public const string? Namespace = null;
+                public static string WithId(string id, bool includeNamespace = false) => $"user:{id}";
             }
 
             public static class Document
             {
                 public const string Name = "document";
-                public static string WithId(string id) => $"document:{id}";
+                public const string? Namespace = null;
+                public static string WithId(string id, bool includeNamespace = false) => $"document:{id}";
                 public static class Relations
                 {
                     public const string Viewer = "viewer";

--- a/tests/SpiceWeaver.Tests/__snapshots__/SchemaSourceGeneratorTests.MultipleSchemas_Mixed_foo.snap
+++ b/tests/SpiceWeaver.Tests/__snapshots__/SchemaSourceGeneratorTests.MultipleSchemas_Mixed_foo.snap
@@ -7,13 +7,15 @@
             public static class User
             {
                 public const string Name = "user";
-                public static string WithId(string id) => $"user:{id}";
+                public const string? Namespace = null;
+                public static string WithId(string id, bool includeNamespace = false) => $"user:{id}";
             }
 
             public static class Document
             {
                 public const string Name = "document";
-                public static string WithId(string id) => $"document:{id}";
+                public const string? Namespace = null;
+                public static string WithId(string id, bool includeNamespace = false) => $"document:{id}";
                 public static class Relations
                 {
                     public const string Viewer = "viewer";

--- a/tests/SpiceWeaver.Tests/__snapshots__/SchemaSourceGeneratorTests.MultipleSchemas_bar.snap
+++ b/tests/SpiceWeaver.Tests/__snapshots__/SchemaSourceGeneratorTests.MultipleSchemas_bar.snap
@@ -7,13 +7,15 @@
             public static class User
             {
                 public const string Name = "user";
-                public static string WithId(string id) => $"user:{id}";
+                public const string? Namespace = null;
+                public static string WithId(string id, bool includeNamespace = false) => $"user:{id}";
             }
 
             public static class Document
             {
                 public const string Name = "document";
-                public static string WithId(string id) => $"document:{id}";
+                public const string? Namespace = null;
+                public static string WithId(string id, bool includeNamespace = false) => $"document:{id}";
                 public static class Relations
                 {
                     public const string Viewer = "viewer";

--- a/tests/SpiceWeaver.Tests/__snapshots__/SchemaSourceGeneratorTests.MultipleSchemas_foo.snap
+++ b/tests/SpiceWeaver.Tests/__snapshots__/SchemaSourceGeneratorTests.MultipleSchemas_foo.snap
@@ -7,13 +7,15 @@
             public static class User
             {
                 public const string Name = "user";
-                public static string WithId(string id) => $"user:{id}";
+                public const string? Namespace = null;
+                public static string WithId(string id, bool includeNamespace = false) => $"user:{id}";
             }
 
             public static class Document
             {
                 public const string Name = "document";
-                public static string WithId(string id) => $"document:{id}";
+                public const string? Namespace = null;
+                public static string WithId(string id, bool includeNamespace = false) => $"document:{id}";
                 public static class Relations
                 {
                     public const string Viewer = "viewer";

--- a/tests/SpiceWeaver.Tests/__snapshots__/SchemaSourceGeneratorTests.SingleSchema_Json.snap
+++ b/tests/SpiceWeaver.Tests/__snapshots__/SchemaSourceGeneratorTests.SingleSchema_Json.snap
@@ -7,13 +7,15 @@
             public static class User
             {
                 public const string Name = "user";
-                public static string WithId(string id) => $"user:{id}";
+                public const string? Namespace = null;
+                public static string WithId(string id, bool includeNamespace = false) => $"user:{id}";
             }
 
             public static class Document
             {
                 public const string Name = "document";
-                public static string WithId(string id) => $"document:{id}";
+                public const string? Namespace = null;
+                public static string WithId(string id, bool includeNamespace = false) => $"document:{id}";
                 public static class Relations
                 {
                     public const string Viewer = "viewer";


### PR DESCRIPTION
* Adds `Namespace` field to definitions. This is always nullable even when a definition has a namespace, for consistency.
* Adds `includeNamespace` optional parameter to `WithId` (defaults to `false`):
```csharp
public const string Name = "user";
public const string? Namespace = "mynamespace";
public static string WithId(string id, bool includeNamespace = false) => includeNamespace ? $"mynamespace/user:{id}" : $"user:{id}";
```

The `includeNamespace` parameter is available even when the definition does not have a namespace for consistency, however the implementation will ignore this:
```csharp
public const string Name = "user";
public const string? Namespace = null;
public static string WithId(string id, bool includeNamespace = false) => $"user:{id}";
```

Closes #24

+semver:minor